### PR TITLE
email confirmation check by centrifuge

### DIFF
--- a/backend/config/webappConfigScheme.js
+++ b/backend/config/webappConfigScheme.js
@@ -7,4 +7,8 @@ module.exports = {
     name: 'VUE_APP_P1PAYAPI_URL',
     default: 'https://p1payapi.tst.protocol.one',
   },
+  websocketUrl: {
+    name: 'VUE_APP_WEBSOCKET_URL',
+    default: 'wss://cf.tst.protocol.one/connection/websocket',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bootstrap": "^4.3.1",
     "bootstrap-vue": "^2.0.0-rc.13",
     "build-url": "^1.3.2",
-    "centrifuge": "^2.0.0",
+    "centrifuge": "^2.2.1",
     "chart.js": "^2.7.3",
     "codecov": "^3.1.0",
     "cross-env": "^5.2.0",

--- a/src/components/ErrorPage.vue
+++ b/src/components/ErrorPage.vue
@@ -9,10 +9,11 @@
 const errorTexts = {
   404: 'Page not found',
   500: 'Server error',
+  520: 'Unknown error',
 };
 
 export default {
-  name: 'Page404',
+  name: 'ErrorPage',
 
   props: {
     errorCode: {

--- a/src/components/UserProfileCompany.vue
+++ b/src/components/UserProfileCompany.vue
@@ -1,6 +1,6 @@
 <script>
 import { filter } from 'lodash-es';
-import { required, maxLength } from 'vuelidate/lib/validators';
+import { required, maxLength, url } from 'vuelidate/lib/validators';
 import { onlyRusAndLat } from '@/helpers/customValidators';
 
 
@@ -185,6 +185,7 @@ export default {
           },
           website: {
             required,
+            url,
           },
           annual_income: {
             required,
@@ -254,6 +255,10 @@ export default {
       label="Website"
       v-model="profile.company.website"
       :required="true"
+      :hasError="$isFieldInvalid('profile.company.website')"
+      :errorText="$getFieldErrorMessages(
+        'profile.company.website', ['url']
+      )"
     />
     <UiSelect
       label="Annual income"

--- a/src/pages/ConfirmEmail.vue
+++ b/src/pages/ConfirmEmail.vue
@@ -1,0 +1,26 @@
+<script>
+import ConfirmEmailStore from '@/store/ConfirmEmailStore';
+
+export default {
+  name: 'ConfirmEmail',
+
+  async asyncData({ store, registerStoreModule, route }) {
+    try {
+      await registerStoreModule('ConfirmEmail', ConfirmEmailStore, route.query.token);
+      store.dispatch('ConfirmEmail/redirectToDashboard');
+    } catch (error) {
+      store.dispatch('setPageError', error);
+    }
+  },
+};
+</script>
+
+<template>
+  <div class="confirm-email">
+    Loading...
+  </div>
+</template>
+<style lang="scss" scoped>
+.confirm-email {
+}
+</style>

--- a/src/pages/UserProfile.vue
+++ b/src/pages/UserProfile.vue
@@ -84,8 +84,14 @@ export default {
     },
   },
 
+  mounted() {
+    if (this.currentStepCode === 'confirmEmail') {
+      this.initWaitingForEmailConfirm();
+    }
+  },
+
   methods: {
-    ...mapActions('UserProfile', ['updateProfile', 'setCurrentStepCode']),
+    ...mapActions('UserProfile', ['updateProfile', 'setCurrentStepCode', 'initWaitingForEmailConfirm']),
 
     handleStepComplete(value) {
       this.currentStep.isValid = value;
@@ -102,6 +108,10 @@ export default {
         });
 
         this.setCurrentStepCode(nextStepCode);
+
+        if (nextStepCode === 'confirmEmail') {
+          this.initWaitingForEmailConfirm();
+        }
       } catch (error) {
         this.$_Notifications_showErrorMessage(error.message);
       }

--- a/src/routes.js
+++ b/src/routes.js
@@ -152,6 +152,10 @@ const routes = [
     component: () => import('@/pages/SignUp.vue'),
     meta: { layout: 'PageShallow' },
   },
+  {
+    path: '/confirm_email/',
+    component: () => import('@/pages/ConfirmEmail.vue'),
+  },
 
   {
     path: '*',

--- a/src/store/ConfirmEmailStore.js
+++ b/src/store/ConfirmEmailStore.js
@@ -1,0 +1,29 @@
+
+import axios from 'axios';
+import router from '@/router';
+
+export default function createUserStore() {
+  return {
+
+    actions: {
+      initState({ dispatch }, token) {
+        return dispatch('confirmEmail', token);
+      },
+
+      async confirmEmail({ rootState }, token) {
+        await axios.put(
+          `${rootState.config.apiUrl}/api/v1/user/confirm_email`,
+          {
+            token,
+          },
+        );
+      },
+
+      redirectToDashboard() {
+        router.push({ path: '/dashboard' });
+      },
+    },
+
+    namespaced: true,
+  };
+}

--- a/src/store/RootStore.js
+++ b/src/store/RootStore.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import axios from 'axios';
-import { includes } from 'lodash-es';
+import { includes, get } from 'lodash-es';
 
 import DictionariesStore from './DictionariesStore';
 import UserStore from './UserStore';
@@ -58,10 +58,17 @@ export default new Vuex.Store({
     setPageError({ commit }, error) {
       if (!error) {
         commit('pageError', null);
-      } else if (error.response && includes([404, 500], error.response.status)) {
-        commit('pageError', error.response.status);
+        return;
+      }
+
+      const awailableCodes = [404, 500, 520];
+      const errorCode = get(error, 'response.status');
+      if (includes(awailableCodes, error)) {
+        commit('pageError', error);
+      } else if (includes(awailableCodes, errorCode)) {
+        commit('pageError', errorCode);
       } else {
-        console.error(error);
+        commit('pageError', 520);
       }
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1814,14 +1814,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.18.0:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
-  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
-  dependencies:
-    follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
-
 axios@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
@@ -2568,7 +2560,7 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.4.tgz#9cf2de494ca84060a2a8d2854edd6dfb0445f386"
   integrity sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==
 
-centrifuge@^2.0.0:
+centrifuge@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/centrifuge/-/centrifuge-2.2.1.tgz#b13c41d358fe85d7465ab2b18eb01ded9616eaf8"
   integrity sha512-wbvjVzYBUOoOrTb/gk1htZUNtlC/PNJ1Hs99bAXP7Wodvzy8b0vHoDb1U4YzwVqEimtwgofDp6D0+r8obMgRsQ==


### PR DESCRIPTION
1. Налажено общение с центрифугой, которая умеет рапортовать об успешном конфирме почты и редиректить после этого в дашборд
2. Создана новая страница для конфирма email-а, которая принимает на вход токен и отправляет запрос на конфирм. Потом тоже редиректт в дашборд